### PR TITLE
Allow custom generic type as value for FormElement

### DIFF
--- a/app/src/main/java/me/riddhimanadib/fastformbuilder/FormListenerActivity.java
+++ b/app/src/main/java/me/riddhimanadib/fastformbuilder/FormListenerActivity.java
@@ -1,8 +1,8 @@
 package me.riddhimanadib.fastformbuilder;
 
+import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.support.v7.widget.RecyclerView;
 import android.view.MenuItem;
 import android.widget.Toast;
@@ -13,10 +13,28 @@ import java.util.List;
 import me.riddhimanadib.formmaster.helper.FormBuildHelper;
 import me.riddhimanadib.formmaster.listener.OnFormElementValueChangedListener;
 import me.riddhimanadib.formmaster.model.FormElement;
-import me.riddhimanadib.formmaster.model.FormHeader;
 import me.riddhimanadib.formmaster.model.FormObject;
 
 public class FormListenerActivity extends AppCompatActivity implements OnFormElementValueChangedListener {
+
+    enum Fruit {
+        BANANA, ORANGE, MANGO, GUAVA;
+
+        public String toString() {
+            switch (this) {
+                case BANANA:
+                    return "Banana";
+                case ORANGE:
+                    return "Orange";
+                case MANGO:
+                    return "Mango";
+                case GUAVA:
+                    return "Guava";
+            }
+
+            return "";
+        }
+    }
 
     private RecyclerView mRecyclerView;
     private FormBuildHelper mFormBuilder;
@@ -66,13 +84,21 @@ public class FormListenerActivity extends AppCompatActivity implements OnFormEle
         FormElement element31 = FormElement.createInstance().setType(FormElement.TYPE_PICKER_DATE).setTitle("Date");
         FormElement element32 = FormElement.createInstance().setType(FormElement.TYPE_PICKER_TIME).setTitle("Time");
         FormElement element33 = FormElement.createInstance().setType(FormElement.TYPE_EDITTEXT_PASSWORD).setTitle("Password").setValue("abcd1234");
-        List<String> fruits = new ArrayList<>();
-        fruits.add("Banana");
-        fruits.add("Orange");
-        fruits.add("Mango");
-        fruits.add("Guava");
-        FormElement element41 = FormElement.createInstance().setType(FormElement.TYPE_SPINNER_DROPDOWN).setTitle("Single Item").setOptions(fruits);
-        FormElement element42 = FormElement.createInstance().setType(FormElement.TYPE_PICKER_MULTI_CHECKBOX).setTitle("Multi Items").setOptions(fruits);
+
+        List<String> fruitStrings = new ArrayList<>();
+        fruitStrings.add("Banana");
+        fruitStrings.add("Orange");
+        fruitStrings.add("Mango");
+        fruitStrings.add("Guava");
+
+        List<Fruit> fruitEnums = new ArrayList<>();
+        fruitEnums.add(Fruit.BANANA);
+        fruitEnums.add(Fruit.ORANGE);
+        fruitEnums.add(Fruit.MANGO);
+        fruitEnums.add(Fruit.GUAVA);
+
+        FormElement element41 = FormElement.<Fruit>createGenericInstance().setType(FormElement.TYPE_SPINNER_DROPDOWN).setTitle("Single Item").setOptions(fruitEnums);
+        FormElement element42 = FormElement.createInstance().setType(FormElement.TYPE_PICKER_MULTI_CHECKBOX).setTitle("Multi Items").setOptions(fruitStrings);
 
         List<FormObject> formItems = new ArrayList<>();
         formItems.add(element11);
@@ -93,6 +119,6 @@ public class FormListenerActivity extends AppCompatActivity implements OnFormEle
 
     @Override
     public void onValueChanged(FormElement formElement) {
-        Toast.makeText(this, formElement.getValue(), Toast.LENGTH_SHORT).show();
+        Toast.makeText(this, formElement.getValue().toString(), Toast.LENGTH_SHORT).show();
     }
 }

--- a/form-master/src/main/java/me/riddhimanadib/formmaster/adapter/FormAdapter.java
+++ b/form-master/src/main/java/me/riddhimanadib/formmaster/adapter/FormAdapter.java
@@ -65,7 +65,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
      * @param formObjects
      */
     public void addElements(List<FormObject> formObjects) {
-        this.mDataset = formObjects;
+        this.mDataset.addAll(formObjects);
     }
 
     /**
@@ -195,6 +195,13 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
             holder.mTextViewTitle.setText(formElement.getTitle());
             holder.mEditTextValue.setText(formElement.getValueAsString());
             holder.mEditTextValue.setHint(formElement.getHint());
+            holder.mEditTextValue.setError(formElement.getError());
+
+            if (formElement.isVisible()) {
+                holder.itemView.setVisibility(View.VISIBLE);
+            } else {
+                holder.itemView.setVisibility(View.GONE);
+            }
 
             switch (getItemViewType(position)) {
                 case FormElement.TYPE_EDITTEXT_TEXT_SINGLELINE:
@@ -373,6 +380,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
                     public void onClick(DialogInterface dialog, int which) {
                         holder.mEditTextValue.setText(options[which]);
                         currentObj.setValue(currentObj.getOptions().get(which));
+                        currentObj.setError(null); // Reset after value change
                         notifyDataSetChanged();
                     }
                 })
@@ -448,6 +456,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
                         }
                         holder.mEditTextValue.setText(s);
                         ((FormElement) mDataset.get(position)).setValue(s);
+                        ((FormElement) mDataset.get(position)).setError(null); // Reset after value change
                         notifyDataSetChanged();
                     }
                 })
@@ -516,6 +525,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
             // trigger event only if the value is changed
             if (!currentValue.equals(newValue)) {
                 formElement.setValue(newValue);
+                formElement.setError(null); // Reset error after text change
                 if (mListener != null)
                     mListener.onValueChanged(formElement);
             }
@@ -551,6 +561,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
                 // trigger event only if the value is changed
                 if (!currentValue.equals(newValue)) {
                     formElement.setValue(newValue);
+                    formElement.setError(null); // Reset after value change
                     notifyDataSetChanged();
                     if (mListener != null)
                         mListener.onValueChanged(formElement);
@@ -585,6 +596,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
                 // trigger event only if the value is changed
                 if (!currentValue.equals(newValue)) {
                     formElement.setValue(newValue);
+                    formElement.setError(null); // Reset after value change
                     notifyDataSetChanged();
                     if (mListener != null)
                         mListener.onValueChanged(formElement);

--- a/form-master/src/main/java/me/riddhimanadib/formmaster/adapter/FormAdapter.java
+++ b/form-master/src/main/java/me/riddhimanadib/formmaster/adapter/FormAdapter.java
@@ -193,7 +193,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
             // other wise, it just displays form element with respective type
             FormElement formElement = (FormElement) currentObject;
             holder.mTextViewTitle.setText(formElement.getTitle());
-            holder.mEditTextValue.setText(formElement.getValue());
+            holder.mEditTextValue.setText(formElement.getValueAsString());
             holder.mEditTextValue.setHint(formElement.getHint());
 
             switch (getItemViewType(position)) {
@@ -363,7 +363,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
         // reformat the options in format needed
         final CharSequence[] options = new CharSequence[currentObj.getOptions().size()];
         for (int i = 0; i < currentObj.getOptions().size(); i++) {
-            options[i] = currentObj.getOptions().get(i);
+            options[i] = currentObj.getOptions().get(i).toString();
         }
 
         // prepare the dialog
@@ -372,7 +372,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
                 .setItems(options, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int which) {
                         holder.mEditTextValue.setText(options[which]);
-                        currentObj.setValue(options[which].toString());
+                        currentObj.setValue(currentObj.getOptions().get(which));
                         notifyDataSetChanged();
                     }
                 })
@@ -406,10 +406,12 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
         final ArrayList<Integer> mSelectedItems = new ArrayList();
 
         for (int i = 0; i < currentObj.getOptions().size(); i++) {
-            options[i] = currentObj.getOptions().get(i);
+            Object obj = currentObj.getOptions().get(i);
+
+            options[i] = obj.toString();
             optionsSelected[i] = false;
 
-            if (currentObj.getOptionsSelected().contains(options[i])) {
+            if (currentObj.getOptionsSelected().contains(obj)) {
                 optionsSelected[i] = true;
                 mSelectedItems.add(i);
             }
@@ -508,7 +510,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
 
             // get current form element, existing value and new value
             FormElement formElement = (FormElement) mDataset.get(position);
-            String currentValue = formElement.getValue();
+            String currentValue = formElement.getValueAsString();
             String newValue = charSequence.toString();
 
             // trigger event only if the value is changed
@@ -543,7 +545,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
             if (clickedPosition >= 0) {
                 // get current form element, existing value and new value
                 FormElement formElement = (FormElement) mDataset.get(clickedPosition);
-                String currentValue = formElement.getValue();
+                String currentValue = formElement.getValue().toString();
                 String newValue = sdfDate.format(mCalendarCurrentDate.getTime());
 
                 // trigger event only if the value is changed
@@ -577,7 +579,7 @@ public class FormAdapter extends RecyclerView.Adapter<FormAdapter.ViewHolder> {
             if (clickedPosition >= 0) {
                 // get current form element, existing value and new value
                 FormElement formElement = (FormElement) mDataset.get(clickedPosition);
-                String currentValue = formElement.getValue();
+                String currentValue = formElement.getValue().toString();
                 String newValue = sdfTime.format(mCalendarCurrentTime.getTime());
 
                 // trigger event only if the value is changed

--- a/form-master/src/main/java/me/riddhimanadib/formmaster/helper/FormBuildHelper.java
+++ b/form-master/src/main/java/me/riddhimanadib/formmaster/helper/FormBuildHelper.java
@@ -93,7 +93,7 @@ public class FormBuildHelper {
     public boolean isValidForm() {
         for (int i = 0; i < this.mFormAdapter.getItemCount(); i++) {
             FormElement formElement = this.mFormAdapter.getValueAtIndex(i);
-            if (formElement.isHeader() == false & formElement.isRequired() & formElement.getValue().trim().isEmpty()) {
+            if (formElement.isHeader() == false & formElement.isRequired() & formElement.getValue().toString().trim().isEmpty()) {
                 return false;
             }
         }

--- a/form-master/src/main/java/me/riddhimanadib/formmaster/model/FormElement.java
+++ b/form-master/src/main/java/me/riddhimanadib/formmaster/model/FormElement.java
@@ -29,7 +29,9 @@ public class FormElement<T extends Object> implements FormObject {
     private List<T> mOptions; // list of options for single and multi picker
     private List<T> mOptionsSelected; // list of selected options for single and multi picker
     private String mHint; // value to be shown if mValue is null
+    private String mError;
     private boolean mRequired; // value to set is the field is required
+    private boolean mVisible = true;
 
     public FormElement() {
     }
@@ -76,8 +78,18 @@ public class FormElement<T extends Object> implements FormObject {
         return this;
     }
 
+    public FormElement<T> setError(String error) {
+        this.mError = error;
+        return this;
+    }
+
     public FormElement<T> setRequired(boolean required) {
         this.mRequired = required;
+        return this;
+    }
+
+    public FormElement<T> setVisible(boolean visible) {
+        this.mVisible = visible;
         return this;
     }
 
@@ -115,8 +127,16 @@ public class FormElement<T extends Object> implements FormObject {
         return (this.mHint == null) ? "" : this.mHint;
     }
 
+    public String getError() {
+        return this.mError;
+    }
+
     public boolean isRequired() {
         return this.mRequired;
+    }
+
+    public boolean isVisible() {
+        return this.mVisible;
     }
 
     public List<T> getOptions() {

--- a/form-master/src/main/java/me/riddhimanadib/formmaster/model/FormElement.java
+++ b/form-master/src/main/java/me/riddhimanadib/formmaster/model/FormElement.java
@@ -2,13 +2,12 @@ package me.riddhimanadib.formmaster.model;
 
 import java.util.ArrayList;
 import java.util.List;
-import me.riddhimanadib.formmaster.listener.OnFormElementValueChangedListener;
 
 /**
  * Created by Adib on 16-Apr-17.
  */
 
-public class FormElement implements FormObject {
+public class FormElement<T extends Object> implements FormObject {
 
     // different types for the form elements
     public static final int TYPE_EDITTEXT_TEXT_SINGLELINE = 1;
@@ -26,9 +25,9 @@ public class FormElement implements FormObject {
     private int mTag; // unique tag to identify the object
     private int mType; // type for the form element
     private String mTitle; // title to be shown on left
-    private String mValue; // value to be shown on right
-    private List<String> mOptions; // list of options for single and multi picker
-    private List<String> mOptionsSelected; // list of selected options for single and multi picker
+    private T mValue; // value to be shown on right
+    private List<T> mOptions; // list of options for single and multi picker
+    private List<T> mOptionsSelected; // list of selected options for single and multi picker
     private String mHint; // value to be shown if mValue is null
     private boolean mRequired; // value to set is the field is required
 
@@ -40,47 +39,54 @@ public class FormElement implements FormObject {
      *
      * @return
      */
-    public static FormElement createInstance() {
-        return new FormElement();
+    public static FormElement<String> createInstance() {
+        return new FormElement<>();
     }
 
+    /**
+     * static method to create instance using
+     * custom generic value type
+     * @return
+     */
+    public static <T> FormElement<T> createGenericInstance() { return new FormElement<T>(); }
+
     // getters and setters
-    public FormElement setTag(int mTag) {
+    public FormElement<T> setTag(int mTag) {
         this.mTag = mTag;
         return this;
     }
 
-    public FormElement setType(int mType) {
+    public FormElement<T> setType(int mType) {
         this.mType = mType;
         return this;
     }
 
-    public FormElement setTitle(String mTitle) {
+    public FormElement<T> setTitle(String mTitle) {
         this.mTitle = mTitle;
         return this;
     }
 
-    public FormElement setValue(String mValue) {
+    public FormElement<T> setValue(T mValue) {
         this.mValue = mValue;
         return this;
     }
 
-    public FormElement setHint(String mHint) {
+    public FormElement<T> setHint(String mHint) {
         this.mHint = mHint;
         return this;
     }
 
-    public FormElement setRequired(boolean required) {
+    public FormElement<T> setRequired(boolean required) {
         this.mRequired = required;
         return this;
     }
 
-    public FormElement setOptions(List<String> mOptions) {
+    public FormElement<T> setOptions(List<T> mOptions) {
         this.mOptions = mOptions;
         return this;
     }
 
-    public FormElement setOptionsSelected(List<String> mOptionsSelected) {
+    public FormElement<T> setOptionsSelected(List<T> mOptionsSelected) {
         this.mOptionsSelected = mOptionsSelected;
         return this;
     }
@@ -97,8 +103,12 @@ public class FormElement implements FormObject {
         return this.mTitle;
     }
 
-    public String getValue() {
-        return (this.mValue == null) ? "" : this.mValue;
+    public T getValue() {
+        return this.mValue;
+    }
+
+    public String getValueAsString() {
+        return (this.mValue == null) ? "" : this.mValue.toString();
     }
 
     public String getHint() {
@@ -109,12 +119,12 @@ public class FormElement implements FormObject {
         return this.mRequired;
     }
 
-    public List<String> getOptions() {
-        return (this.mOptions == null) ? new ArrayList<String>() : this.mOptions;
+    public List<T> getOptions() {
+        return (this.mOptions == null) ? new ArrayList<T>() : this.mOptions;
     }
 
-    public List<String> getOptionsSelected() {
-        return (this.mOptionsSelected == null) ? new ArrayList<String>() : this.mOptionsSelected;
+    public List<T> getOptionsSelected() {
+        return (this.mOptionsSelected == null) ? new ArrayList<T>() : this.mOptionsSelected;
     }
 
     @Override


### PR DESCRIPTION
Change FormElement to be a generic class with value labeled as T - value will be displayed as string through T.toString() Object function.
Use current createInstance() function to create FormElement with default value type of String as used currently. Add another createGenericInstance() function to create different value types, for example: ``FormElement<Enum> e = FormElement.<Enum>createGenericInstance()``;

Add example in FormListenerActivity for usage with Enum.

Also, change the parts in FormAdapter to support getting Objects instead of Strings.